### PR TITLE
support for tuners

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -1692,6 +1692,7 @@
 		43757D131C06F26C00910CB9 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				2984BA8B23AC4BA300FE5EB6 /* Tuning.swift */,
 				43511CDD21FD80AD00566C63 /* RetrospectiveCorrection */,
 				A9FB75F0252BE320004C7D3F /* BolusDosingDecision.swift */,
 				C17824A41E1AD4D100D9D25C /* ManualBolusRecommendation.swift */,
@@ -3410,6 +3411,7 @@
 				E95D380324EADF36005E2F50 /* CarbStoreProtocol.swift in Sources */,
 				E98A55ED24EDD6380008715D /* SettingsStoreProtocol.swift in Sources */,
 				C1FB428F217921D600FAB378 /* PumpManagerUI.swift in Sources */,
+				29BA0ABD23B07A84008512B1 /* Tuner.swift in Sources */,
 				43C513191E864C4E001547C7 /* GlucoseRangeSchedule.swift in Sources */,
 				43A51E1F1EB6D62A000736CC /* CarbAbsorptionViewController.swift in Sources */,
 				43776F901B8022E90074EA36 /* AppDelegate.swift in Sources */,

--- a/Loop/Base.lproj/Main.storyboard
+++ b/Loop/Base.lproj/Main.storyboard
@@ -668,7 +668,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VQT-96-wh7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="840" y="1168"/>
+            <point key="canvasLocation" x="324" y="1210"/>
         </scene>
         <!--Root Navigation Controller-->
         <scene sceneID="II9-on-wj3">

--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -103,6 +103,11 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Loop/Managers/Tuner.swift
+++ b/Loop/Managers/Tuner.swift
@@ -1,0 +1,239 @@
+//
+//  Tuner.swift
+//  Loop
+//
+//  Created by marius eriksen on 12/22/19.
+//  Copyright © 2019 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import LoopKit
+import HealthKit
+
+/// Errors that can occur during tuning.
+enum TunerError: Error {
+    /// If the data provided were unsufficient to perform tuning.
+    case insufficientData
+    /// An other, underlying error occured.
+    case other(_ error: Error)
+    case networkError
+    case serviceError(code: Int, body: String)
+}
+
+/// TunerResult is the result of a tuning operation.
+enum TunerResult {
+    /// Tuning succeeded with the resulting parameter schedules.
+    case success(_ basalRateSchedule: BasalRateSchedule, _ carbRatioSchedule: CarbRatioSchedule, _ insulinSensitivitySchedule: InsulinSensitivitySchedule)
+    /// Tuning failed with the provided error.
+    case failure(_ error: TunerError)
+}
+
+struct TunerInsulinModel {
+    let delay: TimeInterval
+    let peak: TimeInterval
+    let duration: TimeInterval
+
+    var parameters: [String: Double] {
+        get {
+            return [
+                "delay": delay.minutes,
+                "peak": peak.minutes,
+                "duration": duration.minutes,
+            ]
+        }
+    }
+
+    static var defaultModel = TunerInsulinModel(
+        delay: .minutes(5),
+        peak: .minutes(65),
+        duration: .minutes(205))
+}
+
+/// Tuner is implemented by a parameter tuning system.
+protocol Tuner {
+    var smallestRequiredDataInterval: TimeInterval { get }
+    
+    /// Estimate controller parameters using the provided input data.
+    /// - Parameters:
+    ///   - glucoseEntries: All known glucose readings within the modeled time interval. Gaps in glucose readings are assumed to be missing readings.
+    ///   - carbEntries: All known carbohydrate events within the modeled time interval. It is assumed that these entries are complete: gaps are taken to be zero.
+    ///   - insulinEntries: All known insulin delivery events within the modeled time interval. It is assumed that these entries are complete: gaps represent no delivery.
+    ///   - insulinModel: The insulin model used for the aforementioned insulin deliveries.
+    ///   - allowedBasalRates: The set of allowable basal rates in the returned basal rate schedule.
+    ///   - maximumScheduleItemCount: The maximum number of items in the returned basal rate schedule.
+    ///   - minimumTimeInterval: The smallest basal rate schedule interval.
+    ///   - timeZone: The timezone for which this
+    ///   - basalRateSchedule: The user's current basal rate schedule, if any.
+    ///   - insulinSensitivitySchedule: The user's insulin sensitivity schedule, if any.
+    ///   - carbRatioSchedule: The user's carb ratio schedule, if any.
+    ///   - completion: Callback for estimation result.
+    /// TODO: the parameter list is a bit unwieldy; consider using a struct.
+    /// TODO: relax assumptions about insulin deliveries.
+    /// TODO: ideally, we'd track timezones as well, so that models are robust against large timezone changes. this will require extra tracking by Loop, perhaps by assigning timezones as healthkit metadata.
+    func estimateParameters(_ glucoseEntries: [StoredGlucoseSample], _ carbEntries: [StoredCarbEntry], _ insulinEntries: [DoseEntry], _ insulinModel: TunerInsulinModel?, _ allowedBasalRates: [Double], _ maximumScheduleItemCount: Int, _ minimumTimeInterval: TimeInterval, _ timeZone: TimeZone, _ basalRateSchedule: BasalRateSchedule?, _ insulinSensitivitySchedule: InsulinSensitivitySchedule?, _ carbRatioSchedule: CarbRatioSchedule?, completion: @escaping (TunerResult) -> Void)
+}
+
+/// A tuner that calls a remote tuning service (protocol details are available at https://github.com/mariusae/tune/blob/master/README.md).
+struct RemoteTuner: Tuner {
+    let smallestRequiredDataInterval: TimeInterval
+    /// The URL of the tuner service.
+    let url: URL
+   
+    // MARK: - Tuner
+
+    public func estimateParameters(_ glucoseEntries: [StoredGlucoseSample], _ carbEntries: [StoredCarbEntry], _ insulinEntries: [DoseEntry], _ insulinModel: TunerInsulinModel?, _ allowedBasalRates: [Double], _ maximumScheduleItemCount: Int, _ minimumTimeInterval: TimeInterval, _ timeZone: TimeZone, _ basalRateSchedule: BasalRateSchedule?, _ insulinSensitivitySchedule: InsulinSensitivitySchedule?, _ carbRatioSchedule: CarbRatioSchedule?, completion: @escaping (TunerResult) -> Void) {
+        let glucoseTimeline = encodeTimeline(columnType: "glucose", parameters: [:], unit: .milligramsPerDeciliter, samples: glucoseEntries)
+        
+        let insulinParameters = (insulinModel ?? TunerInsulinModel.defaultModel).parameters
+        
+        // We split doses into basals and boluses so that we can attribute durations to the basal entries.
+        // Some models may also want to account for basals explicitly.
+        let insulinTimelines: [TuningTimeline] = Dictionary(grouping: insulinEntries, by: { $0.type }).compactMap { (type, entries) in
+            switch type {
+            case .resume, .suspend:
+                // TODO: check temp resume.
+                return nil
+            case .bolus:
+                let samples = entries.map({ DoseSampleValue(entry: $0) })
+                return encodeTimeline(columnType: "bolus", parameters: insulinParameters, unit: .internationalUnit(), samples: samples)
+            case .basal, .tempBasal:
+                let samples = entries.map({ DoseSampleValue(entry: $0) })
+                return encodeTimeline(columnType: "basal", parameters: insulinParameters, unit: .internationalUnit(), samples: samples)
+            }
+        }
+        
+        let carbTimelines = Dictionary(grouping: carbEntries, by: { $0.absorptionTime ?? TimeInterval(hours: 2) }).map { (absorptionTime, samples) in
+            return encodeTimeline(columnType: "carb", parameters: ["delay": 5.0, "duration": absorptionTime], unit: .gram(), samples: samples)
+        }
+        
+        let basalRateTuningSchedule = basalRateSchedule.map { (schedule) in
+            return TuningSchedule(from: schedule.items)
+        }
+        let insulinSensitivityTuningShedule = insulinSensitivitySchedule.map { (schedule: InsulinSensitivitySchedule) -> TuningSchedule in
+            let items = schedule.items.map { (item: RepeatingScheduleValue<Double>) -> RepeatingScheduleValue<Double> in
+                let quantity = HKQuantity(unit: schedule.unit, doubleValue: item.value)
+                let value = quantity.doubleValue(for: .milligramsPerDeciliter)
+                return RepeatingScheduleValue(startTime: item.startTime, value: value)
+            }
+            return TuningSchedule(from: items)
+        }
+        let carbRatioTuningSchedule = carbRatioSchedule.map { (schedule: CarbRatioSchedule) -> TuningSchedule in
+            let items = schedule.items.map { (item: RepeatingScheduleValue<Double>) -> RepeatingScheduleValue<Double> in
+                let quantity = HKQuantity(unit: schedule.unit, doubleValue: item.value)
+                let value = quantity.doubleValue(for: .gram())
+                return RepeatingScheduleValue(startTime: item.startTime, value: value)
+            }
+            return TuningSchedule(from: items)
+        }
+
+        
+        let payload = TuningRequest(
+            version: 1,
+            timezone: timeZone.identifier,
+            timelines: [glucoseTimeline] + insulinTimelines + carbTimelines,
+            allowedBasalRates: allowedBasalRates,
+            maximumScheduleItemCount: maximumScheduleItemCount,
+            minimumTimeInterval: Int(minimumTimeInterval),
+            basalRateSchedule: basalRateTuningSchedule,
+            insulinSensitivitySchedule: insulinSensitivityTuningShedule,
+            carbRatioSchedule: carbRatioTuningSchedule,
+            basalInsulinParameters: insulinParameters)
+        var jsonData: Data!
+        do {
+            jsonData = try JSONEncoder().encode(payload)
+        } catch {
+            return completion(.failure(.other(error)))
+        }
+        
+        // TODO: compression
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let task = URLSession.shared.uploadTask(with: request, from: jsonData, completionHandler: { (data, response, error) in
+            if let error = error {
+                return completion(.failure(.other(error)))
+            }
+            
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return completion(.failure(.networkError))
+            }
+            
+            if httpResponse.statusCode != 200 {
+                let error = TunerError.serviceError(code: httpResponse.statusCode, body: String(data: data!, encoding: String.Encoding.utf8)!)
+                return completion(.failure(error))
+            }
+            
+            guard let data = data, !data.isEmpty else {
+                let error = TunerError.serviceError(code: 200, body: "no data returned")
+                return completion(.failure(error))
+            }
+            
+            var response: TuningResponse!
+            do {
+                response = try JSONDecoder().decode(TuningResponse.self, from: data)
+            } catch {
+                return completion(.failure(.other(error)))
+            }
+            
+            let basalItems = response.basalRateSchedule.repeatingSchedule
+            let basalSchedule = BasalRateSchedule(dailyItems: basalItems, timeZone: nil)!
+            let carbItems = response.carbRatioSchedule.repeatingSchedule
+            let carbSchedule = CarbRatioSchedule(unit: .gram(), dailyItems: carbItems, timeZone: nil)!
+            let insulinSensitivityItems = response.insulinSensitivitySchedule.repeatingSchedule
+            let insulinSensitivitySchedule = InsulinSensitivitySchedule(unit: .milligramsPerDeciliter, dailyItems: insulinSensitivityItems, timeZone: nil)!
+            completion(.success(basalSchedule, carbSchedule, insulinSensitivitySchedule))
+        })
+        task.resume()
+    }
+    
+    // MARK: - codec
+    
+    func encodeTimeline(columnType: String, parameters: [String: Double], unit: HKUnit, samples: [SampleValue]) -> TuningTimeline {
+        let samples = samples.sorted(by: { $0.startDate < $1.startDate })
+        var index: [Int] = []
+        var values: [Double] = []
+        var durations: [Int] = []
+        for value in samples {
+            index.append(Int(value.startDate.timeIntervalSince1970))
+            values.append(value.quantity.doubleValue(for: unit))
+            durations.append(Int(value.endDate.timeIntervalSince(value.startDate)))
+        }
+        deltaEncode(&index)
+        deltaEncode(&values)
+        deltaEncode(&durations)
+        
+        return TuningTimeline(columnType: columnType, parameters: parameters, index: index, values: values, durations: durations)
+    }
+ 
+    func deltaEncode<T: Numeric>(_ values: inout [T]) {
+        if values.count == 0 {
+            return
+        }
+        for index in (1..<values.count).reversed() {
+            values[index] = values[index] - values[index-1]
+        }
+    }
+}
+
+fileprivate struct DoseSampleValue: SampleValue {
+    let entry: DoseEntry
+    
+    var startDate: Date {
+        get {
+            entry.startDate
+        }
+    }
+    
+    var endDate: Date {
+        get {
+            entry.endDate
+        }
+    }
+    
+    var quantity: HKQuantity {
+        get {
+            return HKQuantity(unit: .internationalUnit(), doubleValue: entry.deliveredUnits ?? entry.programmedUnits)
+        }
+    }
+}

--- a/Loop/Tuning.swift
+++ b/Loop/Tuning.swift
@@ -1,0 +1,140 @@
+//
+//  Tuning.swift
+//  Loop
+//
+//  Created by marius eriksen on 12/19/19.
+//  Copyright © 2019 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import LoopKit
+
+/// A TuningTimeline is a columnar representation of a data timeline, such as glucose, basal, bolus, or carbs. Each column in a TuningTimeline must be of the same length.
+/// TODO: delta encoding should be a coding concern; values here should be represented directly
+struct TuningTimeline: Codable {
+    /// ColumnType is the type of the column. Most tuning services accept "basal", "bolus", "carbs", "glucose", or "insulin".
+    var columnType: String
+    /// Parameters is the set of parameters for the column. For example, insulin columns specify insulin curve parameters; carb columns include carbohydrate parameters.
+    var parameters: [String: Double]
+    /// Index stores the delta-encoded indices of the entries in this timeline. The index is the number of seconds since an epoch. The epoch is the Unix epoch for request timelines. When TuningTimelines are used for parameter schedules, the epoch is midnight (entries are repeating, relative to midnight in the requested timezone).
+    var index: [Int]
+    /// Values stores the delta-encoded values in this timeline, as indexed by the index above.
+    var values: [Double]
+    /// Durations is an optional column that associates durations with each entry. This may be used to represent basal insulin deliveries.
+    var durations: [Int]?
+    
+    enum CodingKeys: String, CodingKey {
+        case columnType = "type"
+        case parameters
+        case index
+        case values
+        case durations
+    }
+}
+
+/// A TunedSchedule represents a parameter schedule recommended by a tuner.
+/// TODO: consider reconciling TuningSchedule and TuningTimeline
+struct TuningSchedule: Codable {
+    init(from schedule: [RepeatingScheduleValue<Double>]) {
+        var index = [Int]()
+        var values = [Double]()
+        index.reserveCapacity(schedule.count)
+        values.reserveCapacity(schedule.count)
+        
+        for value in schedule {
+            index.append(Int(value.startTime.minutes))
+            values.append(value.value)
+        }
+
+        self.index = index
+        self.values = values
+    }
+    
+    /// The index is the number of minutes after midnight the particular parameter value should begin.
+    let index: [Int]
+    /// Values stores the parameter values, indexed by the timestamps above.
+    let values: [Double]
+    
+    /// Represent this schedule as a Loop RepeatingSchedule.
+    var repeatingSchedule: [RepeatingScheduleValue<Double>] {
+        // XXX: figure out if this does the correct thing when
+        // schedules straddle midnight.
+        get {
+            // TODO: this would segfault on a malformed schedule.
+            return index.enumerated().map {
+                RepeatingScheduleValue(startTime: TimeInterval(minutes: Double($1)), value: values[$0])
+            }
+        }
+    }
+}
+
+// MARK: - request
+
+/// TuningRequest encodes a request to a tuning service. It includes all data and parameters required for the tuning service create and train a model.
+struct TuningRequest: Encodable {
+    /// Version indicates the version of the tuning request. It is currently always 1.
+    var version: Int
+    
+    /// Timezone is the user's timezone. This is used to deduce the "time of day" hour of the data that follows, which in turn is used to index parameter schedules.
+    /// TODO: ideally, we'd have a timezone for each data point, but this does not appear to be captured currently.
+    var timezone: String
+    
+    // TODO: add current basals, max basal, allowable basal values, etc.
+    
+    /// Timelines is the set of data timelines to be used as features for the tuner. They typically include basal, bolus, carb, and glucose timelines.
+    var timelines: [TuningTimeline]
+    
+    /// The set of allowable basal rates (U/h).
+    var allowedBasalRates: [Double]
+    
+    /// The maximum allowable number of items in the basal rate schedule.
+    var maximumScheduleItemCount: Int
+    
+    /// The smallest time interval allowable in basal rate schedules (in seconds).
+    var minimumTimeInterval: Int
+    
+    var basalRateSchedule: TuningSchedule?
+    
+    var insulinSensitivitySchedule: TuningSchedule?
+    
+    var carbRatioSchedule: TuningSchedule?
+    
+    var basalInsulinParameters: [String: Double]
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case timezone
+        case timelines
+        case allowedBasalRates = "allowed_basal_rates"
+        case maximumScheduleItemCount = "maximum_schedule_item_count"
+        case minimumTimeInterval = "minimum_time_interval"
+        case basalRateSchedule = "basal_rate_schedule"
+        case insulinSensitivitySchedule = "insulin_sensitivity_schedule"
+        case carbRatioSchedule = "carb_ratio_schedule"
+        case basalInsulinParameters = "basal_insulin_parameters"
+    }
+}
+
+// MARK: - response
+
+// TODO: define errors in the protocol
+
+/// TuningResponses are returned from tuners.
+struct TuningResponse: Decodable {
+    /// The version of the tuning response. Only version 1 is currently supported.
+    let version: Int
+    
+    /// The tuned basal schedule.
+    var basalRateSchedule: TuningSchedule
+    /// The tuned carbohydrate ratio schedule.
+    var carbRatioSchedule: TuningSchedule
+    /// The tuned insulin sensitivity schedule.
+    var insulinSensitivitySchedule: TuningSchedule
+    
+    enum CodingKeys: String, CodingKey {
+        case version = "version"
+        case basalRateSchedule = "basal_rate_schedule"
+        case carbRatioSchedule = "carb_ratio_schedule"
+        case insulinSensitivitySchedule = "insulin_sensitivity_schedule"
+    }
+}

--- a/Loop/View Controllers/LoopTuningResultsTableViewController.swift
+++ b/Loop/View Controllers/LoopTuningResultsTableViewController.swift
@@ -1,0 +1,177 @@
+//
+//  LoopTuningResultsTableViewController.swift
+//  Loop
+//
+//  Created by marius eriksen on 12/16/19.
+//  Copyright © 2019 LoopKit Authors. All rights reserved.
+//
+
+import UIKit
+import LoopKit
+import LoopCore
+import LoopKitUI
+import HealthKit
+
+class LoopTuningResultsTableViewController: SetupTableViewController {
+    // XXX: replace with LoopTuningTunedParameters
+    var basalRateSchedule: BasalRateSchedule!
+    var carbRatioSchedule: CarbRatioSchedule!
+    var sensitivitySchedule: InsulinSensitivitySchedule!
+    
+    var loopTuningDelegate: LoopTuningDelegate?
+
+    // For user modifications:
+    var allowedBasalRates: [Double]!
+    var maximumScheduleItemCount: Int!
+    var minimumTimeInterval: TimeInterval!
+    
+    var settings: LoopSettings!
+
+    fileprivate lazy var valueNumberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+
+        return formatter
+    }()
+    
+    fileprivate enum ResultRow: Int, CaseCountable {
+        case basalRate = 0
+        case carbRatio
+        case sensitivity
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.className)
+        footerView.primaryButton.setTitle("Save", for: .normal)
+    }
+    
+    override func continueButtonPressed(_ sender: Any) {
+        footerView.primaryButton.isEnabled = false      // XXX
+        // footerView.primaryButton.isIndicatingActivity = true
+        navigationItem.rightBarButtonItem?.isEnabled = false   // disable "Cancel"; we can't do anything.
+        loopTuningDelegate?.loopTuningCompleted(withParameters: LoopTuningTunedParameters(basalRateSchedule: basalRateSchedule, carbRatioSchedule: carbRatioSchedule, insulinSensitivitySchedule: sensitivitySchedule))
+    }
+    
+    override func cancelButtonPressed(_: Any) {
+        loopTuningDelegate?.loopTuningCanceled()
+    }
+
+
+    // MARK: - UITableViewDataSource
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard section == 0 else { return super.tableView(tableView, numberOfRowsInSection: section) }
+        return ResultRow.count
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard indexPath.section == 0 else { return super.tableView(tableView, cellForRowAt: indexPath) }
+        
+        let configCell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
+
+        switch ResultRow(rawValue: indexPath.row)! {
+        case .basalRate:
+            configCell.textLabel?.text = NSLocalizedString("Basal Rates", comment: "The title text for the basal rate schedule")
+            configCell.detailTextLabel?.text = valueNumberFormatter.string(from: basalRateSchedule.total(), unit: "U")
+        case .carbRatio:
+            configCell.textLabel?.text = NSLocalizedString("Carb Ratios", comment: "The title text for the carb ratio schedule")
+            let unit = carbRatioSchedule.unit
+            let value = valueNumberFormatter.string(from: carbRatioSchedule.averageQuantity().doubleValue(for: unit)) ?? SettingsTableViewCell.NoValueString
+            configCell.detailTextLabel?.text = String(format: NSLocalizedString("%1$@ %2$@/U", comment: "Format string for carb ratio average. (1: value)(2: carb unit)"), value, unit)
+        case .sensitivity:
+            configCell.textLabel?.text = NSLocalizedString("Insulin Sensitivities", comment: "The title text for the insulin sensitivity schedule")
+            let unit = sensitivitySchedule.unit
+            // Schedule is in mg/dL or mmol/L, but we display as mg/dL/U or mmol/L/U
+            let average = sensitivitySchedule.averageQuantity().doubleValue(for: unit)
+            let unitPerU = unit.unitDivided(by: .internationalUnit())
+            let averageQuantity = HKQuantity(unit: unitPerU, doubleValue: average)
+            let formatter = QuantityFormatter()
+            formatter.setPreferredNumberFormatter(for: unit)
+            configCell.detailTextLabel?.text = formatter.string(from: averageQuantity, for: unitPerU)
+        }
+
+        return configCell
+    }
+
+    override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let sender = tableView.cellForRow(at: indexPath)
+        switch ResultRow(rawValue: indexPath.row)! {
+        case .basalRate:
+            let vc = BasalScheduleTableViewController(allowedBasalRates: allowedBasalRates, maximumScheduleItemCount: maximumScheduleItemCount, minimumTimeInterval: minimumTimeInterval)
+            vc.scheduleItems = basalRateSchedule.items
+            vc.timeZone = basalRateSchedule.timeZone
+
+            vc.title = NSLocalizedString("Basal Rates", comment: "The title of the basal rate profile screen")
+            vc.delegate = self
+            vc.syncSource = nil // TODO: set sync source on the the results table view controller instead, and sync on "save"
+
+            show(vc, sender: sender)
+        case .carbRatio:
+            let scheduleVC = DailyQuantityScheduleTableViewController()
+
+            scheduleVC.delegate = self
+            scheduleVC.title = NSLocalizedString("Carb Ratios", comment: "The title of the carb ratios schedule screen")
+            scheduleVC.unit = .gram()
+
+            scheduleVC.timeZone = carbRatioSchedule.timeZone
+            scheduleVC.scheduleItems = carbRatioSchedule.items
+            scheduleVC.unit = carbRatioSchedule.unit
+            show(scheduleVC, sender: sender)
+        case .sensitivity:
+            let unit = sensitivitySchedule.unit
+            let allowedSensitivityValues = settings.allowedSensitivityValues(for: unit)
+            let scheduleVC = InsulinSensitivityScheduleViewController(allowedValues: allowedSensitivityValues, unit: unit)
+
+            scheduleVC.delegate = self
+            scheduleVC.insulinSensitivityScheduleStorageDelegate = self
+            scheduleVC.title = NSLocalizedString("Insulin Sensitivities", comment: "The title of the insulin sensitivities schedule screen")
+            scheduleVC.schedule = sensitivitySchedule
+
+            show(scheduleVC, sender: sender)
+        }
+    }
+}
+
+extension LoopTuningResultsTableViewController: DailyValueScheduleTableViewControllerDelegate {
+    func dailyValueScheduleTableViewControllerWillFinishUpdating(_ controller: DailyValueScheduleTableViewController) {
+        guard let indexPath = tableView.indexPathForSelectedRow else { return }
+
+        switch ResultRow(rawValue: indexPath.row)! {
+        case .basalRate:
+            let basalVC = controller as! BasalScheduleTableViewController
+            basalRateSchedule = BasalRateSchedule(dailyItems: basalVC.scheduleItems, timeZone: basalVC.timeZone)
+        case let row:
+            if let controller = controller as? DailyQuantityScheduleTableViewController {
+                switch row {
+                case .carbRatio:
+                    carbRatioSchedule = CarbRatioSchedule(unit: controller.unit, dailyItems: controller.scheduleItems, timeZone: controller.timeZone)
+                default:
+                    break
+                }
+            }
+        }
+        
+        tableView.reloadRows(at: [indexPath], with: .none)
+    }
+}
+
+extension LoopTuningResultsTableViewController: InsulinSensitivityScheduleStorageDelegate {
+    func saveSchedule(_ schedule: InsulinSensitivitySchedule, for viewController: InsulinSensitivityScheduleViewController, completion: @escaping (SaveInsulinSensitivityScheduleResult) -> Void) {
+        sensitivitySchedule = schedule
+        completion(.success)
+        tableView.reloadRows(at: [IndexPath(row: ResultRow.sensitivity.rawValue, section: 0)], with: .none)
+    }
+}

--- a/Loop/View Controllers/LoopTuningTableViewController.swift
+++ b/Loop/View Controllers/LoopTuningTableViewController.swift
@@ -1,0 +1,226 @@
+//
+//  LoopTuningTableViewController.swift
+//  Loop
+//
+//  Created by marius eriksen on 12/13/19.
+//  Copyright © 2019 LoopKit Authors. All rights reserved.
+//
+
+// TODO: this should set the insulin model as well; it can be
+//       retrieved from the DoseStore.
+//
+// TODO: total basal deliveries are emitted to health kit data;
+//       so we should be able to go off of this.
+
+import UIKit
+import HealthKit
+import LoopCore
+import LoopKit
+import LoopKitUI
+
+public struct LoopTuningTunedParameters {
+    let basalRateSchedule: BasalRateSchedule
+    let carbRatioSchedule: CarbRatioSchedule
+    let insulinSensitivitySchedule: InsulinSensitivitySchedule
+    
+    // TODO: include insulin curves, etc.
+}
+
+public protocol LoopTuningDelegate: class {
+    func loopTuningCompleted(withParameters parameters: LoopTuningTunedParameters)
+    func loopTuningCanceled()
+}
+
+class LoopTuningTableViewController: SetupTableViewController, IdentifiableClass {
+    var doseStore: DoseStore!
+    var glucoseStore: GlucoseStore!
+    var carbStore: CarbStore!
+    var insulinModelSettings: InsulinModelSettings?
+    var timeZone: TimeZone!
+    
+    var basalRateSchedule: BasalRateSchedule?
+    var insulinSensitivitySchedule: InsulinSensitivitySchedule?
+    var carbRatioSchedule: CarbRatioSchedule?
+
+    var allowedBasalRates: [Double]!
+    var maximumScheduleItemCount: Int!
+    var minimumTimeInterval: TimeInterval!
+    
+    var loopTuningDelegate: LoopTuningDelegate?
+    
+    var settings: LoopSettings!
+    
+//    let tuner: Tuner = RemoteTuner(smallestRequiredDataInterval: .hours(10), url: URL(string: "https://tune.basal.io/standard")!)
+    let tuner: Tuner = RemoteTuner(smallestRequiredDataInterval: .hours(10), url: URL(string: "https://tune.basal.io/sydney")!)
+
+
+//    let tuner: Tuner = RemoteTuner(smallestRequiredDataInterval: .hours(10), url: URL(string: "http://localhost:8080/sydney")!)
+
+    @IBOutlet weak var statusViewCell: UITableViewCell!
+    @IBOutlet weak var statusLabel: UILabel!
+    
+    // TODO: model selection
+    
+    fileprivate enum TuningError: Error {
+        case dataError(error: Error)
+        case testError
+        case serviceError(code: Int, body: String)
+        case networkError
+        case noResponseError
+    }
+
+    fileprivate enum State {
+        case notstarted
+        case preparing
+        case fetched(_ glucoseEntries: [StoredGlucoseSample], _ carbEntries: [StoredCarbEntry], _ insulinEntries: [DoseEntry])
+        case done(_ basalRateSchedule: BasalRateSchedule, _ carbRatioSchedule: CarbRatioSchedule, _ sensitivitySchedule: InsulinSensitivitySchedule)
+        case failure(Error)
+    }
+    
+    private var state: State = .notstarted
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        footerView.primaryButton.isEnabled = true
+    }
+    
+    override func continueButtonPressed(_ sender: Any) {
+        if case .notstarted = state {
+//            print(type(of: footerView.primaryButton))
+//            print(type(of: footerView))
+            // XXX
+            
+//            footerView.primaryButton.isIndicatingActivity = true
+            footerView.primaryButton.isEnabled = false
+            run(state: .notstarted)
+        }
+    }
+    
+    override func cancelButtonPressed(_: Any) {
+        loopTuningDelegate?.loopTuningCanceled()
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        super.prepare(for: segue, sender: sender)
+        guard let vc = segue.destination as? LoopTuningResultsTableViewController,
+            case .done(let basalRateSchedule, let carbRatioSchedule, let sensitivitySchedule) = state else { return }
+        vc.basalRateSchedule = basalRateSchedule
+        vc.carbRatioSchedule = carbRatioSchedule
+        vc.sensitivitySchedule = sensitivitySchedule
+        vc.allowedBasalRates = allowedBasalRates
+        vc.maximumScheduleItemCount = maximumScheduleItemCount
+        vc.minimumTimeInterval = minimumTimeInterval
+        vc.settings = settings
+        vc.loopTuningDelegate = loopTuningDelegate
+    }
+
+    // MARK: - data and state management
+    
+    fileprivate func run(state: State) {
+        print("run \(state)")
+        self.state = state
+        switch state {
+        case .notstarted:
+            run(state: .preparing)
+        case .preparing:
+            fetch()
+        case .fetched(let glucoseEntries, let carbEntries, let insulinEntries):
+            var insulinModel: TunerInsulinModel?
+            // TODO: refactor InsulinModel so that we can extract these parameters directly.
+            switch insulinModelSettings {
+            case .exponentialPreset(.humalogNovologAdult):
+                insulinModel = TunerInsulinModel(delay: .minutes(5), peak: .minutes(75), duration: .minutes(360))
+            case .exponentialPreset(.humalogNovologChild):
+                insulinModel = TunerInsulinModel(delay: .minutes(5), peak: .minutes(65), duration: .minutes(360))
+            case .exponentialPreset(.fiasp):
+                insulinModel = TunerInsulinModel(delay: .minutes(5), peak: .minutes(55), duration: .minutes(360))
+            default:
+                // Will use default.
+                insulinModel = nil
+            }
+            
+            tuner.estimateParameters(glucoseEntries, carbEntries, insulinEntries, insulinModel, allowedBasalRates, maximumScheduleItemCount, minimumTimeInterval, timeZone, basalRateSchedule, insulinSensitivitySchedule, carbRatioSchedule) { (result) in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let basalRateSchedule, let carbRatioSchedule, let insulinSensitivitySchedule):
+                        self.run(state: .done(basalRateSchedule, carbRatioSchedule, insulinSensitivitySchedule))
+                    case .failure(let error):
+                        self.run(state: .failure(error))
+                    }
+                }
+            }
+        case .done(_, _, _):
+            performSegue(withIdentifier: "Continue", sender: self)
+            // Reset so that if we navigate back, we can do it all over again.
+            // XXX
+//            footerView.primaryButton.isIndicatingActivity = false
+            footerView.primaryButton.isEnabled = true
+            self.state = .notstarted
+        case .failure(let error):
+            self.present(UIAlertController(with: error), animated: true)
+            // XXX
+            //footerView.primaryButton.isIndicatingActivity = false
+            self.state = .notstarted
+        }
+    }
+    
+    fileprivate func fetch() {
+        let updateGroup = DispatchGroup()
+        
+        let start = Date(timeIntervalSinceNow: .hours(-24*30*3))
+        
+        var glucoseResult: GlucoseStoreResult<[StoredGlucoseSample]>!
+        updateGroup.enter()
+        glucoseStore?.getGlucoseSamples(start: start) { (result) -> Void in
+            glucoseResult = result
+            updateGroup.leave()
+        }
+
+        var insulinResult: DoseStoreResult<[DoseEntry]>!
+        updateGroup.enter()
+        doseStore?.getNormalizedDoseEntries(start: start) { (result) -> Void in
+            insulinResult = result
+            updateGroup.leave()
+        }
+
+        var carbResult: CarbStoreResult<[StoredCarbEntry]>!
+        updateGroup.enter()
+        carbStore?.getCarbEntries(start: start) { (result) -> Void in
+            carbResult = result
+            updateGroup.leave()
+        }
+        
+        updateGroup.notify(qos: .utility, flags: [], queue: DispatchQueue.main) {
+            var glucoseEntries: [StoredGlucoseSample] = []
+            switch glucoseResult {
+            case .failure(let error):
+                return self.run(state: .failure(TuningError.dataError(error: error)))
+            case .success(let entries):
+                glucoseEntries = entries
+            case .none:
+                // This will always result in an error, but we'll take it through the flow.
+                break
+            }
+            var insulinEntries: [DoseEntry] = []
+            switch insulinResult {
+            case .failure(let error):
+                return self.run(state: .failure(TuningError.dataError(error: error)))
+            case .success(let entries):
+                insulinEntries = entries
+            case .none:
+                break
+            }
+            var carbEntries: [StoredCarbEntry] = []
+            switch carbResult {
+            case .failure(let error):
+                return self.run(state: .failure(TuningError.dataError(error: error)))
+            case .success(let entries):
+                carbEntries = entries
+            case .none:
+                break
+            }
+            
+            self.run(state: .fetched(glucoseEntries, carbEntries, insulinEntries))
+        }
+    }
+}

--- a/Loop/View Controllers/LoopTuningViewController.swift
+++ b/Loop/View Controllers/LoopTuningViewController.swift
@@ -1,0 +1,25 @@
+//
+//  LoopTuningViewController.swift
+//  Loop
+//
+//  Created by marius eriksen on 12/14/19.
+//  Copyright © 2019 LoopKit Authors. All rights reserved.
+//
+
+import UIKit
+import LoopKit
+import LoopCore
+
+class LoopTuningViewController: UINavigationController, UINavigationControllerDelegate, IdentifiableClass {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+//        navigationBar.shadowImage = UIImage()
+        delegate = self
+      }
+
+    // MARK: - UINavigationControllerDelegate
+    open func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+//          let viewControllers = navigationController.viewControllers
+//          let count = navigationController.viewControllers.count
+    }
+}

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -1,0 +1,964 @@
+//
+//  SettingsTableViewController.swift
+//  Naterade
+//
+//  Created by Nathan Racklyeft on 8/29/15.
+//  Copyright © 2015 Nathan Racklyeft. All rights reserved.
+//
+
+import UIKit
+import HealthKit
+import LoopKit
+import LoopKitUI
+import LoopCore
+import LoopTestingKit
+
+
+final class SettingsTableViewController: UITableViewController {
+
+    @IBOutlet var devicesSectionTitleView: UIView?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 44
+
+        tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.className)
+        tableView.register(SettingsImageTableViewCell.self, forCellReuseIdentifier: SettingsImageTableViewCell.className)
+        tableView.register(SwitchTableViewCell.self, forCellReuseIdentifier: SwitchTableViewCell.className)
+        tableView.register(TextButtonTableViewCell.self, forCellReuseIdentifier: TextButtonTableViewCell.className)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        AnalyticsManager.shared.didDisplaySettingsScreen()
+    }
+
+    var dataManager: DeviceDataManager!
+
+    private lazy var isTestingPumpManager = dataManager.pumpManager is TestingPumpManager
+    private lazy var isTestingCGMManager = dataManager.cgmManager is TestingCGMManager
+
+    fileprivate enum Section: Int, CaseIterable {
+        case loop = 0
+        case pump
+        case cgm
+        case configuration
+        case services
+        case testingPumpDataDeletion
+        case testingCGMDataDeletion
+    }
+
+    fileprivate enum LoopRow: Int, CaseCountable {
+        case dosing = 0
+        case diagnostic
+    }
+
+    fileprivate enum PumpRow: Int, CaseCountable {
+        case pumpSettings = 0
+    }
+
+    fileprivate enum CGMRow: Int, CaseCountable {
+        case cgmSettings = 0
+    }
+
+    fileprivate enum ConfigurationRow: Int, CaseCountable {
+        case glucoseTargetRange = 0
+        case suspendThreshold
+        case basalRate
+        case deliveryLimits
+        case insulinModel
+        case carbRatio
+        case insulinSensitivity
+        case overridePresets
+        case tuning
+    }
+
+    fileprivate enum ServiceRow: Int, CaseCountable {
+        case nightscout = 0
+        case loggly
+        case amplitude
+    }
+
+    fileprivate lazy var valueNumberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+
+        return formatter
+    }()
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        switch segue.destination {
+        case let vc as InsulinModelSettingsViewController:
+            vc.deviceManager = dataManager
+            vc.insulinModel = dataManager.loopManager.insulinModelSettings?.model
+
+            if let insulinSensitivitySchedule = dataManager.loopManager.insulinSensitivitySchedule {
+                vc.insulinSensitivitySchedule = insulinSensitivitySchedule
+            }
+
+            vc.delegate = self
+        case let vc as UINavigationController:
+            if let topVC = vc.topViewController, let tuneVC = topVC as? LoopTuningTableViewController {
+                tuneVC.doseStore = dataManager.loopManager.doseStore
+                tuneVC.glucoseStore = dataManager.loopManager.glucoseStore
+                tuneVC.carbStore = dataManager.loopManager.carbStore
+                tuneVC.insulinModelSettings = dataManager.loopManager.insulinModelSettings
+                tuneVC.allowedBasalRates = dataManager.pumpManager!.supportedBasalRates
+                tuneVC.maximumScheduleItemCount = dataManager.pumpManager!.maximumBasalScheduleEntryCount
+                tuneVC.minimumTimeInterval = dataManager.pumpManager!.minimumBasalScheduleEntryDuration
+                tuneVC.settings = dataManager.loopManager.settings
+                if let profile = dataManager.loopManager.basalRateSchedule {
+                    tuneVC.timeZone = profile.timeZone
+                } else {
+                    tuneVC.timeZone = dataManager.pumpManager!.status.timeZone
+                }
+                tuneVC.basalRateSchedule = dataManager.loopManager.basalRateSchedule
+                tuneVC.insulinSensitivitySchedule = dataManager.loopManager.insulinSensitivitySchedule
+                tuneVC.carbRatioSchedule = dataManager.loopManager.carbRatioSchedule
+                tuneVC.loopTuningDelegate = self
+            }
+        default:
+            break
+        }
+    }
+    
+    func configuredSetupViewController(for pumpManager: PumpManagerUI.Type) -> (UIViewController & PumpManagerSetupViewController & CompletionNotifying) {
+        var setupViewController = pumpManager.setupViewController()
+        setupViewController.setupDelegate = self
+        setupViewController.completionDelegate = self
+        setupViewController.basalSchedule = dataManager.loopManager.basalRateSchedule
+        setupViewController.maxBolusUnits = dataManager.loopManager.settings.maximumBolus
+        setupViewController.maxBasalRateUnitsPerHour = dataManager.loopManager.settings.maximumBasalRatePerHour
+        return setupViewController
+    }
+    
+    // MARK: - UITableViewDataSource
+
+    private var sections: [Section] {
+        var sections = Section.allCases
+        if !isTestingPumpManager {
+            sections.remove(.testingPumpDataDeletion)
+        }
+        if !isTestingCGMManager {
+            sections.remove(.testingCGMDataDeletion)
+        }
+        return sections
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch sections[section] {
+        case .loop:
+            return LoopRow.count
+        case .pump:
+            return PumpRow.count
+        case .cgm:
+            return CGMRow.count
+        case .configuration:
+            if FeatureFlags.sensitivityOverridesEnabled {
+                return ConfigurationRow.count
+            } else {
+                return ConfigurationRow.count - 1
+            }
+        case .services:
+            return ServiceRow.count
+        case .testingPumpDataDeletion, .testingCGMDataDeletion:
+            return 1
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch sections[indexPath.section] {
+        case .loop:
+            switch LoopRow(rawValue: indexPath.row)! {
+            case .dosing:
+                let switchCell = tableView.dequeueReusableCell(withIdentifier: SwitchTableViewCell.className, for: indexPath) as! SwitchTableViewCell
+
+                switchCell.selectionStyle = .none
+                switchCell.switch?.isOn = dataManager.loopManager.settings.dosingEnabled
+                switchCell.textLabel?.text = NSLocalizedString("Closed Loop", comment: "The title text for the looping enabled switch cell")
+
+                switchCell.switch?.addTarget(self, action: #selector(dosingEnabledChanged(_:)), for: .valueChanged)
+
+                return switchCell
+            case .diagnostic:
+                let cell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
+
+                cell.textLabel?.text = NSLocalizedString("Issue Report", comment: "The title text for the issue report cell")
+                cell.detailTextLabel?.text = nil
+                cell.accessoryType = .disclosureIndicator
+
+                return cell
+            }
+        case .pump:
+            switch PumpRow(rawValue: indexPath.row)! {
+            case .pumpSettings:
+                if let pumpManager = dataManager.pumpManager {
+                    let cell = tableView.dequeueReusableCell(withIdentifier: SettingsImageTableViewCell.className, for: indexPath)
+                    cell.imageView?.image = pumpManager.smallImage
+                    cell.textLabel?.text = pumpManager.localizedTitle
+                    cell.detailTextLabel?.text = nil
+                    return cell
+                } else {
+                    let cell = tableView.dequeueReusableCell(withIdentifier: TextButtonTableViewCell.className, for: indexPath)
+                    cell.textLabel?.text = NSLocalizedString("Add Pump", comment: "Title text for button to set up a new pump")
+                    return cell
+                }
+            }
+        case .cgm:
+            if let cgmManager = dataManager.cgmManager {
+                let cgmManagerUI = cgmManager as? CGMManagerUI
+
+                let image = cgmManagerUI?.smallImage
+                let cell = tableView.dequeueReusableCell(withIdentifier: image == nil ? SettingsTableViewCell.className : SettingsImageTableViewCell.className, for: indexPath)
+                if let image = image {
+                    cell.imageView?.image = image
+                }
+                cell.textLabel?.text = cgmManager.localizedTitle
+                cell.detailTextLabel?.text = nil
+                return cell
+            } else {
+                let cell = tableView.dequeueReusableCell(withIdentifier: TextButtonTableViewCell.className, for: indexPath)
+                cell.textLabel?.text = NSLocalizedString("Add CGM", comment: "Title text for button to set up a CGM")
+                return cell
+            }
+        case .configuration:
+            let configCell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
+
+            switch ConfigurationRow(rawValue: indexPath.row)! {
+            case .carbRatio:
+                configCell.textLabel?.text = NSLocalizedString("Carb Ratios", comment: "The title text for the carb ratio schedule")
+
+                if let carbRatioSchedule = dataManager.loopManager.carbRatioSchedule {
+                    let unit = carbRatioSchedule.unit
+                    let value = valueNumberFormatter.string(from: carbRatioSchedule.averageQuantity().doubleValue(for: unit)) ?? SettingsTableViewCell.NoValueString
+
+                    configCell.detailTextLabel?.text = String(format: NSLocalizedString("%1$@ %2$@/U", comment: "Format string for carb ratio average. (1: value)(2: carb unit)"), value, unit)
+                } else {
+                    configCell.detailTextLabel?.text = SettingsTableViewCell.TapToSetString
+                }
+            case .insulinSensitivity:
+                configCell.textLabel?.text = NSLocalizedString("Insulin Sensitivities", comment: "The title text for the insulin sensitivity schedule")
+
+                if let insulinSensitivitySchedule = dataManager.loopManager.insulinSensitivitySchedule {
+                    let unit = insulinSensitivitySchedule.unit
+                    // Schedule is in mg/dL or mmol/L, but we display as mg/dL/U or mmol/L/U
+                    let average = insulinSensitivitySchedule.averageQuantity().doubleValue(for: unit)
+                    let unitPerU = unit.unitDivided(by: .internationalUnit())
+                    let averageQuantity = HKQuantity(unit: unitPerU, doubleValue: average)
+                    let formatter = QuantityFormatter()
+                    formatter.setPreferredNumberFormatter(for: unit)
+                    configCell.detailTextLabel?.text = formatter.string(from: averageQuantity, for: unitPerU)
+                } else {
+                    configCell.detailTextLabel?.text = SettingsTableViewCell.TapToSetString
+                }
+            case .glucoseTargetRange:
+                configCell.textLabel?.text = NSLocalizedString("Correction Range", comment: "The title text for the glucose target range schedule")
+
+                if let glucoseTargetRangeSchedule = dataManager.loopManager.settings.glucoseTargetRangeSchedule {
+                    let unit = glucoseTargetRangeSchedule.unit
+                    let value = glucoseTargetRangeSchedule.value(at: Date())
+                    let minTarget = valueNumberFormatter.string(from: value.minValue) ?? SettingsTableViewCell.NoValueString
+                    let maxTarget = valueNumberFormatter.string(from: value.maxValue) ?? SettingsTableViewCell.NoValueString
+
+                    configCell.detailTextLabel?.text = String(format: NSLocalizedString("%1$@ – %2$@ %3$@", comment: "Format string for glucose target range. (1: Min target)(2: Max target)(3: glucose unit)"), minTarget, maxTarget, unit.localizedShortUnitString)
+                } else {
+                    configCell.detailTextLabel?.text = SettingsTableViewCell.TapToSetString
+                }
+            case .suspendThreshold:
+                configCell.textLabel?.text = NSLocalizedString("Suspend Threshold", comment: "The title text in settings")
+                
+                if let suspendThreshold = dataManager.loopManager.settings.suspendThreshold {
+                    let value = valueNumberFormatter.string(from: suspendThreshold.value, unit: suspendThreshold.unit) ?? SettingsTableViewCell.TapToSetString
+                    configCell.detailTextLabel?.text = value
+                } else {
+                    configCell.detailTextLabel?.text = SettingsTableViewCell.TapToSetString
+                }
+            case .insulinModel:
+                configCell.textLabel?.text = NSLocalizedString("Insulin Model", comment: "The title text for the insulin model setting row")
+
+                if let settings = dataManager.loopManager.insulinModelSettings {
+                    configCell.detailTextLabel?.text = settings.title
+                } else {
+                    configCell.detailTextLabel?.text = SettingsTableViewCell.TapToSetString
+                }
+            case .deliveryLimits:
+                configCell.textLabel?.text = NSLocalizedString("Delivery Limits", comment: "Title text for delivery limits")
+
+                if dataManager.loopManager.settings.maximumBolus == nil || dataManager.loopManager.settings.maximumBasalRatePerHour == nil {
+                    configCell.detailTextLabel?.text = SettingsTableViewCell.TapToSetString
+                } else {
+                    configCell.detailTextLabel?.text = SettingsTableViewCell.EnabledString
+                }
+            case .basalRate:
+                configCell.textLabel?.text = NSLocalizedString("Basal Rates", comment: "The title text for the basal rate schedule")
+
+                if let basalRateSchedule = dataManager.loopManager.basalRateSchedule {
+                    configCell.detailTextLabel?.text = valueNumberFormatter.string(from: basalRateSchedule.total(), unit: "U")
+                } else {
+                    configCell.detailTextLabel?.text = SettingsTableViewCell.TapToSetString
+                }
+            case .overridePresets:
+                configCell.textLabel?.text = NSLocalizedString("Override Presets", comment: "The title text for the override presets")
+                let maxPreviewSymbolCount = 3
+                let presetPreviewText = dataManager.loopManager.settings.overridePresets
+                    .prefix(maxPreviewSymbolCount)
+                    .map { $0.symbol }
+                    .joined(separator: " ")
+                configCell.detailTextLabel?.text = presetPreviewText
+            case .tuning:
+                let cell = tableView.dequeueReusableCell(withIdentifier: TextButtonTableViewCell.className, for: indexPath) as! TextButtonTableViewCell
+                cell.textLabel?.text = "Tune Loop Parameters"
+                cell.textLabel?.textAlignment = .center
+                cell.tintColor = nil
+                cell.isEnabled = true
+                return cell
+            }
+
+            configCell.accessoryType = .disclosureIndicator
+            return configCell
+        case .services:
+            let configCell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
+
+            switch ServiceRow(rawValue: indexPath.row)! {
+            case .nightscout:
+                let nightscoutService = dataManager.remoteDataManager.nightscoutService
+
+                configCell.textLabel?.text = nightscoutService.title
+                configCell.detailTextLabel?.text = nightscoutService.siteURL?.absoluteString ?? SettingsTableViewCell.TapToSetString
+            case .loggly:
+                let logglyService = DiagnosticLogger.shared.logglyService
+
+                configCell.textLabel?.text = logglyService.title
+                configCell.detailTextLabel?.text = logglyService.isAuthorized ? SettingsTableViewCell.EnabledString : SettingsTableViewCell.TapToSetString
+            case .amplitude:
+                let amplitudeService = AnalyticsManager.shared.amplitudeService
+
+                configCell.textLabel?.text = amplitudeService.title
+                configCell.detailTextLabel?.text = amplitudeService.isAuthorized ? SettingsTableViewCell.EnabledString : SettingsTableViewCell.TapToSetString
+            }
+
+            configCell.accessoryType = .disclosureIndicator
+            return configCell
+        case .testingPumpDataDeletion:
+            let cell = tableView.dequeueReusableCell(withIdentifier: TextButtonTableViewCell.className, for: indexPath) as! TextButtonTableViewCell
+            cell.textLabel?.text = "Delete Pump Data"
+            cell.textLabel?.textAlignment = .center
+            cell.tintColor = .delete
+            cell.isEnabled = true
+            return cell
+        case .testingCGMDataDeletion:
+            let cell = tableView.dequeueReusableCell(withIdentifier: TextButtonTableViewCell.className, for: indexPath) as! TextButtonTableViewCell
+            cell.textLabel?.text = "Delete CGM Data"
+            cell.textLabel?.textAlignment = .center
+            cell.tintColor = .delete
+            cell.isEnabled = true
+            return cell
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch sections[section] {
+        case .loop:
+            return Bundle.main.localizedNameAndVersion
+        case .pump:
+            return NSLocalizedString("Pump", comment: "The title of the pump section in settings")
+        case .cgm:
+            return NSLocalizedString("Continuous Glucose Monitor", comment: "The title of the continuous glucose monitor section in settings")
+        case .configuration:
+            return NSLocalizedString("Configuration", comment: "The title of the configuration section in settings")
+        case .services:
+            return NSLocalizedString("Services", comment: "The title of the services section in settings")
+        case .testingPumpDataDeletion, .testingCGMDataDeletion:
+            return nil
+        }
+    }
+
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let sender = tableView.cellForRow(at: indexPath)
+
+        switch sections[indexPath.section] {
+        case .pump:
+            switch PumpRow(rawValue: indexPath.row)! {
+            case .pumpSettings:
+                if var settings = dataManager.pumpManager?.settingsViewController() {
+                    settings.completionDelegate = self
+                    present(settings, animated: true)
+                    tableView.deselectRow(at: indexPath, animated: true)
+                } else {
+                    // Add new pump
+                    let pumpManagers = dataManager.availablePumpManagers
+
+                    switch pumpManagers.count {
+                    case 1:
+                        if let pumpManager = pumpManagers.first, let PumpManagerType = dataManager.pumpManagerTypeByIdentifier(pumpManager.identifier) {
+
+                            let setupViewController = configuredSetupViewController(for: PumpManagerType)
+                            present(setupViewController, animated: true, completion: nil)
+                        }
+                        tableView.deselectRow(at: indexPath, animated: true)
+                    case let x where x > 1:
+                        let alert = UIAlertController(pumpManagers: pumpManagers) { [weak self] (identifier) in
+                            if let self = self, let manager = self.dataManager.pumpManagerTypeByIdentifier(identifier) {
+                                let setupViewController = self.configuredSetupViewController(for: manager)
+                                self.present(setupViewController, animated: true, completion: nil)
+                                self.tableView.deselectRow(at: indexPath, animated: true)
+                            }
+                        }
+
+                        alert.addCancelAction { (_) in
+                            tableView.deselectRow(at: indexPath, animated: true)
+                        }
+
+                        present(alert, animated: true, completion: nil)
+                    default:
+                        break
+                    }
+                }
+            }
+        case .cgm:
+            if let cgmManager = dataManager.cgmManager as? CGMManagerUI {
+                if let unit = dataManager.loopManager.glucoseStore.preferredUnit {
+                    var settings = cgmManager.settingsViewController(for: unit)
+                    settings.completionDelegate = self
+                    present(settings, animated: true)
+                    tableView.deselectRow(at: indexPath, animated: true)
+                }
+            } else if dataManager.cgmManager is PumpManagerUI {
+                // The pump manager is providing glucose, but allow reverting the CGM
+                let alert = UIAlertController(deleteCGMManagerHandler: { [weak self] (isDeleted) in
+                    if isDeleted {
+                        self?.dataManager.cgmManager = nil
+                    }
+
+                    tableView.deselectRow(at: indexPath, animated: true)
+                    self?.updateCGMManagerRows()
+                })
+                present(alert, animated: true, completion: nil)
+            } else {
+                // Add new CGM
+                let cgmManagers = allCGMManagers.compactMap({ $0 as? CGMManagerUI.Type })
+
+                switch cgmManagers.count {
+                case 1:
+                    if let CGMManagerType = cgmManagers.first {
+                        setupCGMManager(CGMManagerType)
+                    }
+
+                    tableView.deselectRow(at: indexPath, animated: true)
+                case let x where x > 1:
+                    let alert = UIAlertController(cgmManagers: cgmManagers, pumpManager: dataManager.pumpManager as? CGMManager) { [weak self] (cgmManager, pumpManager) in
+                        if let CGMManagerType = cgmManager {
+                            self?.setupCGMManager(CGMManagerType)
+                        } else if let pumpManager = pumpManager {
+                            self?.completeCGMManagerSetup(pumpManager)
+                        }
+
+                        tableView.deselectRow(at: indexPath, animated: true)
+                    }
+
+                    alert.addCancelAction { (_) in
+                        tableView.deselectRow(at: indexPath, animated: true)
+                    }
+
+                    present(alert, animated: true, completion: nil)
+                default:
+                    break
+                }
+            }
+        case .configuration:
+            let row = ConfigurationRow(rawValue: indexPath.row)!
+            switch row {
+            case .carbRatio:
+                let scheduleVC = DailyQuantityScheduleTableViewController()
+
+                scheduleVC.delegate = self
+                scheduleVC.title = NSLocalizedString("Carb Ratios", comment: "The title of the carb ratios schedule screen")
+                scheduleVC.unit = .gram()
+
+                if let schedule = dataManager.loopManager.carbRatioSchedule {
+                    scheduleVC.timeZone = schedule.timeZone
+                    scheduleVC.scheduleItems = schedule.items
+                    scheduleVC.unit = schedule.unit
+                } else if let timeZone = dataManager.pumpManager?.status.timeZone {
+                    scheduleVC.timeZone = timeZone
+                }
+
+                show(scheduleVC, sender: sender)
+            case .insulinSensitivity:
+                let unit = dataManager.loopManager.insulinSensitivitySchedule?.unit ?? dataManager.loopManager.glucoseStore.preferredUnit ?? HKUnit.milligramsPerDeciliter
+                let allowedSensitivityValues = dataManager.loopManager.settings.allowedSensitivityValues(for: unit)
+                let scheduleVC = InsulinSensitivityScheduleViewController(allowedValues: allowedSensitivityValues, unit: unit)
+
+                scheduleVC.delegate = self
+                scheduleVC.insulinSensitivityScheduleStorageDelegate = self
+                scheduleVC.title = NSLocalizedString("Insulin Sensitivities", comment: "The title of the insulin sensitivities schedule screen")
+
+                scheduleVC.schedule = dataManager.loopManager.insulinSensitivitySchedule
+
+                show(scheduleVC, sender: sender)
+            case .glucoseTargetRange:
+                let unit = dataManager.loopManager.settings.glucoseTargetRangeSchedule?.unit ?? dataManager.loopManager.glucoseStore.preferredUnit ?? HKUnit.milligramsPerDeciliter
+                let allowedCorrectionRangeValues = dataManager.loopManager.settings.allowedCorrectionRangeValues(for: unit)
+                let scheduleVC = GlucoseRangeScheduleTableViewController(allowedValues: allowedCorrectionRangeValues, unit: unit)
+
+                if FeatureFlags.sensitivityOverridesEnabled {
+                    scheduleVC.overrideContexts.remove(.legacyWorkout)
+                }
+
+                scheduleVC.delegate = self
+                scheduleVC.title = NSLocalizedString("Correction Range", comment: "The title of the glucose target range schedule screen")
+
+                if let schedule = dataManager.loopManager.settings.glucoseTargetRangeSchedule {
+                    var overrides: [TemporaryScheduleOverride.Context: DoubleRange] = [:]
+                    overrides[.preMeal] = dataManager.loopManager.settings.preMealTargetRange.filter { !$0.isZero }
+                    overrides[.legacyWorkout] = dataManager.loopManager.settings.legacyWorkoutTargetRange.filter { !$0.isZero }
+                    scheduleVC.setSchedule(schedule, withOverrideRanges: overrides)
+                }
+
+                show(scheduleVC, sender: sender)
+            case .suspendThreshold:
+                if let minBGGuard = dataManager.loopManager.settings.suspendThreshold {
+                    let vc = GlucoseThresholdTableViewController(threshold: minBGGuard.value, glucoseUnit: minBGGuard.unit)
+                    vc.delegate = self
+                    vc.indexPath = indexPath
+                    vc.title = sender?.textLabel?.text
+                    self.show(vc, sender: sender)
+                } else if let unit = dataManager.loopManager.glucoseStore.preferredUnit {
+                    let vc = GlucoseThresholdTableViewController(threshold: nil, glucoseUnit: unit)
+                    vc.delegate = self
+                    vc.indexPath = indexPath
+                    vc.title = sender?.textLabel?.text
+                    self.show(vc, sender: sender)
+                }
+            case .insulinModel:
+                performSegue(withIdentifier: InsulinModelSettingsViewController.className, sender: sender)
+            case .deliveryLimits:
+                let vc = DeliveryLimitSettingsTableViewController(style: .grouped)
+
+                vc.maximumBasalRatePerHour = dataManager.loopManager.settings.maximumBasalRatePerHour
+                vc.maximumBolus = dataManager.loopManager.settings.maximumBolus
+
+                vc.title = sender?.textLabel?.text
+                vc.delegate = self
+                vc.syncSource = dataManager.pumpManager
+
+                show(vc, sender: sender)
+            case .basalRate:
+                guard let pumpManager = dataManager.pumpManager else {
+                    // Not allowing basal schedule entry without a configured pump.
+                    tableView.deselectRow(at: indexPath, animated: true)
+                    return
+                }
+                let vc = BasalScheduleTableViewController(allowedBasalRates: pumpManager.supportedBasalRates, maximumScheduleItemCount: pumpManager.maximumBasalScheduleEntryCount, minimumTimeInterval: pumpManager.minimumBasalScheduleEntryDuration)
+
+                if let profile = dataManager.loopManager.basalRateSchedule {
+                    vc.scheduleItems = profile.items
+                    vc.timeZone = profile.timeZone
+                } else {
+                    vc.timeZone = pumpManager.status.timeZone
+                }
+
+                vc.title = NSLocalizedString("Basal Rates", comment: "The title of the basal rate profile screen")
+                vc.delegate = self
+                vc.syncSource = pumpManager
+
+                show(vc, sender: sender)
+            case .overridePresets:
+                guard let glucoseUnit = dataManager.loopManager.glucoseStore.preferredUnit else { break }
+                let vc = OverridePresetTableViewController(
+                    glucoseUnit: glucoseUnit,
+                    presets: dataManager.loopManager.settings.overridePresets
+                )
+                vc.delegate = self
+
+                show(vc, sender: sender)
+            case .tuning:
+                tableView.deselectRow(at: indexPath, animated: true)
+                guard dataManager.pumpManager != nil else {
+                    // Not allowing tuning without a configured pump.
+                    return
+                }
+                performSegue(withIdentifier: LoopTuningViewController.className, sender: sender)
+            }
+        case .loop:
+            switch LoopRow(rawValue: indexPath.row)! {
+            case .diagnostic:
+                let vc = CommandResponseViewController.generateDiagnosticReport(deviceManager: dataManager)
+                vc.title = sender?.textLabel?.text
+
+                show(vc, sender: sender)
+            case .dosing:
+                break
+            }
+        case .services:
+            switch ServiceRow(rawValue: indexPath.row)! {
+            case .nightscout:
+                let service = dataManager.remoteDataManager.nightscoutService
+                let vc = AuthenticationViewController(authentication: service)
+                vc.authenticationObserver = { [weak self] (service) in
+                    self?.dataManager.remoteDataManager.nightscoutService = service
+
+                    self?.tableView.reloadRows(at: [indexPath], with: .none)
+                }
+
+                show(vc, sender: sender)
+            case .loggly:
+                let service = DiagnosticLogger.shared.logglyService
+                let vc = AuthenticationViewController(authentication: service)
+                vc.authenticationObserver = { [weak self] (service) in
+                    DiagnosticLogger.shared.logglyService = service
+
+                    self?.tableView.reloadRows(at: [indexPath], with: .none)
+                }
+
+                show(vc, sender: sender)
+            case .amplitude:
+                let service = AnalyticsManager.shared.amplitudeService
+                let vc = AuthenticationViewController(authentication: service)
+                vc.authenticationObserver = { [weak self] (service) in
+                    AnalyticsManager.shared.amplitudeService = service
+
+                    self?.tableView.reloadRows(at: [indexPath], with: .none)
+                }
+
+                show(vc, sender: sender)
+            }
+        case .testingPumpDataDeletion:
+            let confirmVC = UIAlertController(pumpDataDeletionHandler: { self.dataManager.deleteTestingPumpData() })
+            present(confirmVC, animated: true) {
+                tableView.deselectRow(at: indexPath, animated: true)
+            }
+        case .testingCGMDataDeletion:
+            let confirmVC = UIAlertController(cgmDataDeletionHandler: { self.dataManager.deleteTestingCGMData() })
+            present(confirmVC, animated: true) {
+                tableView.deselectRow(at: indexPath, animated: true)
+            }
+        }
+    }
+
+    @objc private func dosingEnabledChanged(_ sender: UISwitch) {
+        dataManager.loopManager.settings.dosingEnabled = sender.isOn
+    }
+}
+
+// MARK: - DeviceManager view controller delegation
+
+extension SettingsTableViewController: CompletionDelegate {
+    func completionNotifyingDidComplete(_ object: CompletionNotifying) {
+        if let vc = object as? UIViewController, presentedViewController === vc {
+            dismiss(animated: true, completion: nil)
+
+            updateSelectedDeviceManagerRows()
+        }
+    }
+
+    private func updateSelectedDeviceManagerRows() {
+        updatePumpManagerRows()
+        updateCGMManagerRows()
+    }
+
+    private func updatePumpManagerRows() {
+        tableView.beginUpdates()
+
+        let previousTestingPumpDataDeletionSection = sections.firstIndex(of: .testingPumpDataDeletion)
+        let wasTestingPumpManager = isTestingPumpManager
+        isTestingPumpManager = dataManager.pumpManager is TestingPumpManager
+        if !wasTestingPumpManager, isTestingPumpManager {
+            guard let testingPumpDataDeletionSection = sections.firstIndex(of: .testingPumpDataDeletion) else {
+                fatalError("Expected to find testing pump data deletion section with testing pump in use")
+            }
+            tableView.insertSections([testingPumpDataDeletionSection], with: .automatic)
+        } else if wasTestingPumpManager, !isTestingPumpManager {
+            guard let previousTestingPumpDataDeletionSection = previousTestingPumpDataDeletionSection else {
+                fatalError("Expected to have had testing pump data deletion section when testing pump was in use")
+            }
+            tableView.deleteSections([previousTestingPumpDataDeletionSection], with: .automatic)
+        }
+
+
+        tableView.reloadSections([Section.pump.rawValue], with: .fade)
+        tableView.reloadSections([Section.cgm.rawValue], with: .fade)
+        tableView.endUpdates()
+    }
+
+    private func updateCGMManagerRows() {
+        tableView.beginUpdates()
+
+        let previousTestingCGMDataDeletionSection = sections.firstIndex(of: .testingCGMDataDeletion)
+        let wasTestingCGMManager = isTestingCGMManager
+        isTestingCGMManager = dataManager.cgmManager is TestingCGMManager
+        if !wasTestingCGMManager, isTestingCGMManager {
+            guard let testingCGMDataDeletionSection = sections.firstIndex(of: .testingCGMDataDeletion) else {
+                fatalError("Expected to find testing CGM data deletion section with testing CGM in use")
+            }
+            tableView.insertSections([testingCGMDataDeletionSection], with: .automatic)
+        } else if wasTestingCGMManager, !isTestingCGMManager {
+            guard let previousTestingCGMDataDeletionSection = previousTestingCGMDataDeletionSection else {
+                fatalError("Expected to have had testing CGM data deletion section when testing CGM was in use")
+            }
+            tableView.deleteSections([previousTestingCGMDataDeletionSection], with: .automatic)
+        }
+
+        tableView.reloadSections([Section.cgm.rawValue], with: .fade)
+        tableView.endUpdates()
+    }
+}
+
+
+extension SettingsTableViewController: PumpManagerSetupViewControllerDelegate {
+    func pumpManagerSetupViewController(_ pumpManagerSetupViewController: PumpManagerSetupViewController, didSetUpPumpManager pumpManager: PumpManagerUI) {
+        dataManager.pumpManager = pumpManager
+
+        if let basalRateSchedule = pumpManagerSetupViewController.basalSchedule {
+            dataManager.loopManager.basalRateSchedule = basalRateSchedule
+            tableView.reloadRows(at: [[Section.configuration.rawValue, ConfigurationRow.basalRate.rawValue]], with: .none)
+        }
+
+        if let maxBasalRateUnitsPerHour = pumpManagerSetupViewController.maxBasalRateUnitsPerHour {
+            dataManager.loopManager.settings.maximumBasalRatePerHour = maxBasalRateUnitsPerHour
+            tableView.reloadRows(at: [[Section.configuration.rawValue, ConfigurationRow.deliveryLimits.rawValue]], with: .none)
+        }
+
+        if let maxBolusUnits = pumpManagerSetupViewController.maxBolusUnits {
+            dataManager.loopManager.settings.maximumBolus = maxBolusUnits
+            tableView.reloadRows(at: [[Section.configuration.rawValue, ConfigurationRow.deliveryLimits.rawValue]], with: .none)
+        }
+    }
+}
+
+
+extension SettingsTableViewController: CGMManagerSetupViewControllerDelegate {
+    fileprivate func setupCGMManager(_ CGMManagerType: CGMManagerUI.Type) {
+        if var setupViewController = CGMManagerType.setupViewController() {
+            setupViewController.setupDelegate = self
+            setupViewController.completionDelegate = self
+            present(setupViewController, animated: true, completion: nil)
+        } else {
+            completeCGMManagerSetup(CGMManagerType.init(rawState: [:]))
+        }
+    }
+
+    fileprivate func completeCGMManagerSetup(_ cgmManager: CGMManager?) {
+        dataManager.cgmManager = cgmManager
+
+        updateSelectedDeviceManagerRows()
+    }
+
+    func cgmManagerSetupViewController(_ cgmManagerSetupViewController: CGMManagerSetupViewController, didSetUpCGMManager cgmManager: CGMManagerUI) {
+        completeCGMManagerSetup(cgmManager)
+    }
+}
+
+
+extension SettingsTableViewController: DailyValueScheduleTableViewControllerDelegate {
+    func dailyValueScheduleTableViewControllerWillFinishUpdating(_ controller: DailyValueScheduleTableViewController) {
+        guard let indexPath = tableView.indexPathForSelectedRow else {
+            return
+        }
+
+        switch sections[indexPath.section] {
+        case .configuration:
+            switch ConfigurationRow(rawValue: indexPath.row)! {
+            case .basalRate:
+                if let controller = controller as? BasalScheduleTableViewController {
+                    dataManager.loopManager.basalRateSchedule = BasalRateSchedule(dailyItems: controller.scheduleItems, timeZone: controller.timeZone)
+                }
+            case let row:
+                if let controller = controller as? DailyQuantityScheduleTableViewController {
+                    switch row {
+                    case .carbRatio:
+                        dataManager.loopManager.carbRatioSchedule = CarbRatioSchedule(unit: controller.unit, dailyItems: controller.scheduleItems, timeZone: controller.timeZone)
+                        AnalyticsManager.shared.didChangeCarbRatioSchedule()
+                    default:
+                        break
+                    }
+                }
+            }
+        default:
+            break
+        }
+
+        tableView.reloadRows(at: [indexPath], with: .none)
+    }
+}
+
+extension SettingsTableViewController: GlucoseRangeScheduleStorageDelegate {
+    func saveSchedule(for viewController: GlucoseRangeScheduleTableViewController, completion: @escaping (SaveGlucoseRangeScheduleResult) -> Void) {
+        dataManager.loopManager.settings.preMealTargetRange = viewController.overrideRanges[.preMeal].filter { !$0.isZero }
+        dataManager.loopManager.settings.legacyWorkoutTargetRange = viewController.overrideRanges[.legacyWorkout].filter { !$0.isZero }
+        dataManager.loopManager.settings.glucoseTargetRangeSchedule = viewController.schedule
+        completion(.success)
+        tableView.reloadRows(at: [IndexPath(row: ConfigurationRow.glucoseTargetRange.rawValue, section: Section.configuration.rawValue)], with: .none)
+    }
+}
+
+extension SettingsTableViewController: InsulinSensitivityScheduleStorageDelegate {
+    func saveSchedule(_ schedule: InsulinSensitivitySchedule, for viewController: InsulinSensitivityScheduleViewController, completion: @escaping (SaveInsulinSensitivityScheduleResult) -> Void) {
+        dataManager.loopManager.insulinSensitivitySchedule = schedule
+        AnalyticsManager.shared.didChangeInsulinSensitivitySchedule()
+        completion(.success)
+        tableView.reloadRows(at: [IndexPath(row: ConfigurationRow.insulinSensitivity.rawValue, section: Section.configuration.rawValue)], with: .none)
+    }
+}
+
+extension SettingsTableViewController: InsulinModelSettingsViewControllerDelegate {
+    func insulinModelSettingsViewControllerDidChangeValue(_ controller: InsulinModelSettingsViewController) {
+        guard let indexPath = self.tableView.indexPathForSelectedRow else {
+            return
+        }
+
+        switch sections[indexPath.section] {
+        case .configuration:
+            switch ConfigurationRow(rawValue: indexPath.row)! {
+            case .insulinModel:
+                if let model = controller.insulinModel {
+                    dataManager.loopManager.insulinModelSettings = InsulinModelSettings(model: model)
+                }
+
+                tableView.reloadRows(at: [indexPath], with: .none)
+            default:
+                assertionFailure()
+            }
+        default:
+            assertionFailure()
+        }
+    }
+}
+
+
+extension SettingsTableViewController: LoopKitUI.TextFieldTableViewControllerDelegate {
+    func textFieldTableViewControllerDidEndEditing(_ controller: LoopKitUI.TextFieldTableViewController) {
+        if let indexPath = controller.indexPath {
+            switch sections[indexPath.section] {
+            case .configuration:
+                switch ConfigurationRow(rawValue: indexPath.row)! {
+                case .suspendThreshold:
+                    if let controller = controller as? GlucoseThresholdTableViewController,
+                        let value = controller.value, let minBGGuard = valueNumberFormatter.number(from: value)?.doubleValue {
+                        dataManager.loopManager.settings.suspendThreshold = GlucoseThreshold(unit: controller.glucoseUnit, value: minBGGuard)
+                    } else {
+                        dataManager.loopManager.settings.suspendThreshold = nil
+                    }
+                default:
+                    assertionFailure()
+                }
+            default:
+                assertionFailure()
+            }
+        }
+
+        tableView.reloadData()
+    }
+
+    func textFieldTableViewControllerDidReturn(_ controller: LoopKitUI.TextFieldTableViewController) {
+        _ = navigationController?.popViewController(animated: true)
+    }
+}
+
+
+extension SettingsTableViewController: DeliveryLimitSettingsTableViewControllerDelegate {
+    func deliveryLimitSettingsTableViewControllerDidUpdateMaximumBasalRatePerHour(_ vc: DeliveryLimitSettingsTableViewController) {
+        dataManager.loopManager.settings.maximumBasalRatePerHour = vc.maximumBasalRatePerHour
+
+        tableView.reloadRows(at: [[Section.configuration.rawValue, ConfigurationRow.deliveryLimits.rawValue]], with: .none)
+    }
+
+    func deliveryLimitSettingsTableViewControllerDidUpdateMaximumBolus(_ vc: DeliveryLimitSettingsTableViewController) {
+        dataManager.loopManager.settings.maximumBolus = vc.maximumBolus
+
+        tableView.reloadRows(at: [[Section.configuration.rawValue, ConfigurationRow.deliveryLimits.rawValue]], with: .none)
+    }
+}
+
+
+extension SettingsTableViewController: OverridePresetTableViewControllerDelegate {
+    func overridePresetTableViewControllerDidUpdatePresets(_ vc: OverridePresetTableViewController) {
+        dataManager.loopManager.settings.overridePresets = vc.presets
+
+        tableView.reloadRows(at: [[Section.configuration.rawValue, ConfigurationRow.overridePresets.rawValue]], with: .none)
+    }
+}
+
+extension SettingsTableViewController: LoopTuningDelegate {
+    func loopTuningCanceled() {
+        dismiss(animated: true, completion: nil)
+    }
+    
+    func loopTuningCompleted(withParameters parameters: LoopTuningTunedParameters) {
+        let basalVC = BasalScheduleTableViewController(allowedBasalRates: [], maximumScheduleItemCount: 0, minimumTimeInterval: TimeInterval.minutes(0))
+        basalVC.scheduleItems = parameters.basalRateSchedule.items
+        dataManager.pumpManager!.syncScheduleValues(for: basalVC) { (result) in
+            DispatchQueue.main.async {
+                self.dismiss(animated: true, completion: nil)
+                switch result {
+                case .success(let items, let timeZone):
+                    self.dataManager.loopManager.basalRateSchedule = BasalRateSchedule(dailyItems: items, timeZone: timeZone)
+                    self.dataManager.loopManager.insulinSensitivitySchedule = parameters.insulinSensitivitySchedule
+                    AnalyticsManager.shared.didChangeInsulinSensitivitySchedule()
+                    // For some reason, the loop manager takes care of calling into the AnalyticsManager for basal rate schedule changes, but not the others.
+                    self.dataManager.loopManager.basalRateSchedule = parameters.basalRateSchedule
+                    self.dataManager.loopManager.carbRatioSchedule = parameters.carbRatioSchedule
+                    AnalyticsManager.shared.didChangeCarbRatioSchedule()
+                    self.tableView.reloadRows(at: [
+                        IndexPath(row: ConfigurationRow.insulinSensitivity.rawValue, section: Section.configuration.rawValue),
+                        IndexPath(row: ConfigurationRow.basalRate.rawValue, section: Section.configuration.rawValue),
+                        IndexPath(row: ConfigurationRow.carbRatio.rawValue, section: Section.configuration.rawValue),
+                    ], with: .none)
+                case .failure(let error):
+                    self.present(UIAlertController(with: error), animated: true)
+                }
+
+            }
+        }
+    }
+}
+
+private extension UIAlertController {
+    convenience init(pumpDataDeletionHandler handler: @escaping () -> Void) {
+        self.init(
+            title: nil,
+            message: "Are you sure you want to delete testing pump health data?",
+            preferredStyle: .actionSheet
+        )
+
+        addAction(UIAlertAction(
+            title: "Delete Pump Data",
+            style: .destructive,
+            handler: { _ in handler() }
+        ))
+
+        addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+    }
+
+    convenience init(cgmDataDeletionHandler handler: @escaping () -> Void) {
+        self.init(
+            title: nil,
+            message: "Are you sure you want to delete testing CGM health data?",
+            preferredStyle: .actionSheet
+        )
+
+        addAction(UIAlertAction(
+            title: "Delete CGM Data",
+            style: .destructive,
+            handler: { _ in handler() }
+        ))
+
+        addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+    }
+}

--- a/LoopCore/Insulin/ExponentialInsulinModelPreset.swift
+++ b/LoopCore/Insulin/ExponentialInsulinModelPreset.swift
@@ -1,0 +1,63 @@
+//
+//  ExponentialInsulinModelPreset.swift
+//  Loop
+//
+//  Copyright © 2017 LoopKit Authors. All rights reserved.
+//
+
+import LoopKit
+
+
+public enum ExponentialInsulinModelPreset: String {
+    case humalogNovologAdult
+    case humalogNovologChild
+    case fiasp
+}
+
+
+// MARK: - Model generation
+public extension ExponentialInsulinModelPreset {
+    var actionDuration: TimeInterval {
+        switch self {
+        case .humalogNovologAdult:
+            return .minutes(360)
+        case .humalogNovologChild:
+            return .minutes(360)
+        case .fiasp:
+            return .minutes(360)
+        }
+    }
+
+    var peakActivity: TimeInterval {
+        switch self {
+        case .humalogNovologAdult:
+            return .minutes(75)
+        case .humalogNovologChild:
+            return .minutes(65)
+        case .fiasp:
+            return .minutes(55)
+        }
+    }
+
+    var model: InsulinModel {
+        return ExponentialInsulinModel(actionDuration: actionDuration, peakActivityTime: peakActivity)
+    }
+}
+
+
+extension ExponentialInsulinModelPreset: InsulinModel {
+    public var effectDuration: TimeInterval {
+        return model.effectDuration
+    }
+
+    public func percentEffectRemaining(at time: TimeInterval) -> Double {
+        return model.percentEffectRemaining(at: time)
+    }
+}
+
+
+extension ExponentialInsulinModelPreset: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "\(self.rawValue)(\(String(reflecting: model))"
+    }
+}


### PR DESCRIPTION
This change adds support for parameter tuners to Loop,
with an accompanying UI to tune, review, and save tuned
parameters.

There is currently only one implemenation of tuners:
remote tuners package up relevant data, and send a tuning
request to a web service, which in turn responds with the
tuned parameters. The protocol is documented elsewhere [1].
This allows for experimentation with multiple tuning approaches,
and also to use tools that have rich support for data science
and machine learning (e.g., python).

A model based tuner is implemented in [1].

[1] https://github.com/mariusae/tune/tree/master/README.md